### PR TITLE
Detect and fix drift in Z work coordinate offset

### DIFF
--- a/autolevel.js
+++ b/autolevel.js
@@ -145,8 +145,10 @@ module.exports = class Autolevel {
     let dy = (ymax - ymin) / parseInt((ymax - ymin) / this.delta)
     code.push('(AL: probing initial point)')
     code.push(`G21`)
-    code.push(`G90 G0 X${xmin.toFixed(3)} Y${ymin.toFixed(3)} Z${this.height}`)
-    code.push(`G38.2 Z-${this.height} F${this.feed / 2}`)
+    code.push(`G90`)
+    code.push(`G0 Z${this.height}`)
+    code.push(`G0 X${xmin.toFixed(3)} Y${ymin.toFixed(3)} Z${this.height}`)
+    code.push(`G38.2 Z-${this.height+1} F${this.feed / 2}`)
     code.push(`G10 L20 P1 Z0`) // set the z zero
     code.push(`G0 Z${this.height}`)
     this.planedPointCount++

--- a/autolevel.js
+++ b/autolevel.js
@@ -174,6 +174,18 @@ module.exports = class Autolevel {
     this.sckw.sendGcode(code.join('\n'))
   }
 
+  updateContext(context) {
+      if (this.wco.z != 0 &&
+          context.mposz !== undefined &&
+          context.posz !== undefined) {
+          let wcoz = context.mposz - context.posz;
+          if (Math.abs(this.wco.z - wcoz) > 0.00001) {
+             this.wco.z = wcoz;
+             console.log('WARNING: WCO Z offset drift detected! wco.z is now: ' + this.wco.z);
+          }
+      }    
+  }
+
   stripComments(line) {
     const re1 = new RegExp(/\s*\([^\)]*\)/g) // Remove anything inside the parentheses
     const re2 = new RegExp(/\s*;.*/g) // Remove anything after a semi-colon to the end of the line, including preceding spaces

--- a/autolevel.js
+++ b/autolevel.js
@@ -166,7 +166,7 @@ module.exports = class Autolevel {
         if (x > xmax) x = xmax
         code.push(`(AL: probing point ${this.planedPointCount + 1})`)
         code.push(`G90 G0 X${x.toFixed(3)} Y${y.toFixed(3)} Z${this.height}`)
-        code.push(`G38.2 Z-${this.height} F${this.feed}`)
+        code.push(`G38.2 Z-${this.height+1} F${this.feed}`)
         code.push(`G0 Z${this.height}`)
         this.planedPointCount++
       }

--- a/index.js
+++ b/index.js
@@ -163,5 +163,8 @@ function callback (err, socket) {
     } else if (data.indexOf('#autolevel') >= 0 && context && context.source === 'feeder') {
       autolevel.start(data, context)
     }
+    else {
+      autolevel.updateContext(context)
+    }
   })
 }


### PR DESCRIPTION
I found on my machine that when probing a large set of points, the coordinate offset from machine to work coordinates for the Z axis would drift, sometimes by as much as 1/2 a mm (probably due to a missed step at some point). This causes all subsequent probe depths to be wrong, which in turn corrupts the entire auto level calculation.

This PR constantly monitors the offset and updates internally so probe calculations are correct.  I also added a small change to add an extra mm to the probe depth to compensate for changes in the working height.
