### PR TITLE
Support for persistent autolevel data

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,16 @@ Please, note that this command will be ignored when put inside the gcode file or
 
 Once the probing is finished and gcode updated you may run the gcode.
 
-You can customize the probing distance, height and feedrate you may use the following syntax:
+You can customize the probing distance, height and feedrate and/or probing mode by using the following syntax:
 
 ```
-(#autolevel D[distance] H[height] F[feedrate] M[margin])
+(#autolevel D[distance] H[height] F[feedrate] M[margin] P[probeOnly])
 ```
+
+The "probeOnly" value indicates if the probing should be applied to any loaded GCode or not. The default value of "0" indicates that yes, the probe results should be applied immediately to any loaded GCode.  A probeOnly of "1" indicates that
+probing should NOT be applied to any loaded GCode. This special mode is used in conjunction with the PROBEOPEN command to save probe values to an external file (see below). This is the only mode that allows probing to occur where no g-code is
+currently loaded.
+
 
 If a new related gcode is needed, after the first mill process. Autolevel values can be reapplyed with the following command:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ node . --help
 | -------------- | ---------- |
 | `(#autolevel)` | Probes the Z-offset in a grid way fixing the uploaded gcode. |
 | `(#autolevel_reapply)` | reapply previous probed Z-offset values when importing a new gcode |
+| `(PROBEOPEN filename)` | save the probed values to a file named 'filename'
+| `(PROBECLOSE)` | close the probe capture file opened with PROBEOPEN. This happens automatically when (#autolevel) completes, so this is only for probe commands issued by other software
 
 
 ### Installation with `pm2`
@@ -54,21 +56,25 @@ Then, by using a macro you may send the following command:
 (#autolevel)
 ```
 
-Without any options it will probe every 10 mm, with travel height at 2 mm, and probing feedrate 50 mm/min.
+Without any options it will probe the area covered by the gcode every 10 mm, with travel height at 2 mm, and probing feedrate 50 mm/min.
     
 Please, note that this command will be ignored when put inside the gcode file or type it in the console, you must run it from a macro.
 
-Once the probing is finished and gcode updated you may run the gcode.
+Once the probing is finished, the loaded gcode will be updated to reflect probed z levels and you may run the gcode.
 
 You can customize the probing distance, height and feedrate and/or probing mode by using the following syntax:
 
 ```
-(#autolevel D[distance] H[height] F[feedrate] M[margin] P[probeOnly])
+(#autolevel D[distance] H[height] F[feedrate] M[margin] P[probeOnly] X[xSize] Y[ySize])
 ```
 
 The "probeOnly" value indicates if the probing should be applied to any loaded GCode or not. The default value of "0" indicates that yes, the probe results should be applied immediately to any loaded GCode.  A probeOnly of "1" indicates that
 probing should NOT be applied to any loaded GCode. This special mode is used in conjunction with the PROBEOPEN command to save probe values to an external file (see below). This is the only mode that allows probing to occur where no g-code is
 currently loaded.
+
+The probed area will be comprised of cells that are each "distance" in width and height. Normally, the area covered
+by the loaded gcode is probed. However, if no gcode is loaded (for example, in the case of a probeOnly), you can
+instead expliticly specify the max X,Y size with the xSize,ySize parameters.  In that case, the probe area will be 0,0 to xSize,YSize.
 
 
 If a new related gcode is needed, after the first mill process. Autolevel values can be reapplyed with the following command:
@@ -79,10 +85,18 @@ If a new related gcode is needed, after the first mill process. Autolevel values
 
 In the case of the different drill bit lengths, after changing the drill bit to another having different length, you have to Z-Probe the PCB surface at approximately starting point (xmin, ymin) and set the Z WCO to zero again before firing the `#autolevel_reapply` command.
 
-### Custom usage example
+### Custom usage examples
 
 ```
 (#autolevel D7.5 H1.0 F20 M0.2)
 ```
 
 This will instruct it to use probing distance of 7.5 mm (i.e. distance in XY plane between probed points), travel height 1 mm and feedrate 20.0 mm/min considerin a margin of 0.2 mm around the PCB area.
+
+
+
+```
+(#autolevel P1 X30 Y50)
+```
+
+This will instruct it to probe an area area 30mm by 50 mm (starting at the work zero) using use default probing distance of 10 mm, travel height 2 mm and feedrate 50.0 mm/min. The loaded gcode will NOT be modified. If a (PROBEOPEN) has not been issued to save the values to a specific file, the probed values will be saved to a default file that can be used in a future run using (#autolevel_reapply).

--- a/autolevel.js
+++ b/autolevel.js
@@ -95,6 +95,13 @@ module.exports = class Autolevel {
             y: prb[1] - this.wco.y,
             z: prb[2] - this.wco.z
           }
+
+          if (this.probeFile) {
+            // Write the results to the probe file. Use 9 point format for compatibility
+            // with LinuxCNC probe file format
+            fs.writeSync(this.probeFile, `${pt.x} ${pt.y} ${pt.z} 0 0 0 0 0 0\n`);
+          }
+
           if (this.planedPointCount > 0) {
             if(this.probedPoints.length ===0) {
               this.min_dz = pt.z;
@@ -107,12 +114,6 @@ module.exports = class Autolevel {
             }
             this.probedPoints.push(pt)
 
-            if (this.probeFile) {
-              // Write the results to the probe file. Use 9 point format for compatibility
-              // with LinuxCNC probe file format
-              fs.writeSync(this.probeFile, `${pt.x} ${pt.y} ${pt.z} 0 0 0 0 0 0\n`);
-            }
-
             console.log('probed ' + this.probedPoints.length + '/' + this.planedPointCount + '>', pt.x.toFixed(3), pt.y.toFixed(3), pt.z.toFixed(3))
             // send info to console
             if (this.probedPoints.length >= this.planedPointCount) {
@@ -124,6 +125,7 @@ module.exports = class Autolevel {
                  this.applyCompensation()
               }
               this.planedPointCount = 0
+              this.wco = { x: 0, y: 0, z: 0 }              
             }
           }
         }
@@ -146,7 +148,8 @@ module.exports = class Autolevel {
 
   fileClose() {
       if (this.probeFile) {
-         fs.closeSync(this.probeFile);
+        console.log('Closing probe file');
+        fs.closeSync(this.probeFile);
          this.probeFile = 0;
       }
   }

--- a/index.js
+++ b/index.js
@@ -168,14 +168,16 @@ function callback (err, socket) {
       autolevel.reapply(data, context)
     } else if (data.indexOf('#autolevel') >= 0 && context && context.source === 'feeder') {
       autolevel.start(data, context)
-    } else if (data.indexOf('PROBEOPEN')) {
+    } else if (data.indexOf('PROBEOPEN') > 0) {
+      console.log(`Probe file open command: ${data}`);
       let startNdx = data.indexOf('PROBEOPEN') + 9;
       let endParen = data.indexOf(')');
       if (endParen > 0) {
          let fileName = data.substring(startNdx, endParen).trim();
          autolevel.fileOpen(fileName);
       }
-    } else if (data.indexOf('PROBECLOSE') >= 0) {
+    } else if (data.indexOf('PROBECLOSE') > 0) {
+         console.log('Probe file close command');
          autolevel.fileClose();
     }
     else {

--- a/index.js
+++ b/index.js
@@ -156,12 +156,27 @@ socket.on('serialport:error', function (options) {
 
 // eslint-disable-next-line handle-callback-err
 function callback (err, socket) {
+
+  if (err) {
+    // SOME kind of error handling if an error occurs
+    throw err;
+  }  
+
   let autolevel = new Autolevel(socket, options)
   socket.on('serialport:write', function (data, context) {
     if (data.indexOf('#autolevel_reapply') >= 0 && context && context.source === 'feeder') {
       autolevel.reapply(data, context)
     } else if (data.indexOf('#autolevel') >= 0 && context && context.source === 'feeder') {
       autolevel.start(data, context)
+    } else if (data.indexOf('PROBEOPEN')) {
+      let startNdx = data.indexOf('PROBEOPEN') + 9;
+      let endParen = data.indexOf(')');
+      if (endParen > 0) {
+         let fileName = data.substring(startNdx, endParen).trim();
+         autolevel.fileOpen(fileName);
+      }
+    } else if (data.indexOf('PROBECLOSE') >= 0) {
+         autolevel.fileClose();
     }
     else {
       autolevel.updateContext(context)


### PR DESCRIPTION
This PR adds support to cncjs-kt-ext to allow previous probe values to be persisted to files for future use (e.g. following a reset or power failure).  To that end, cnc-kt-ext has been enhanced with the following features:

1. Support for (PROBEOPEN filename) and (PROBECLOSE) comments as found in LinuxCNC
2.  Support for additional optional parameters on (#autolevel) comment that allows a PCB to be probed with no g-code currently loaded
3. Probing done in the absence of a (PROBEOPEN) comment is saved to a file that is automatically re-loaded at startup, allowing (#autolevel_reapply) to be used immediately following a power failure.

LinuxCNC is a popular system for controlling CNC mills. One of its features is the ability to save autolevel probe data to a file using the (PROBEOPEN someFileName) comment. Some open source software is capable of using this data to generate gcode with autoleveled data integrated into it. This PR saves its files in the same file format as LinuxCNC's (PROBEOPEN) command, making it compatible with those software projects.

If no (PROBEOPEN) command is explicitly issued, a default probe capture file is used. If this capture file is found at system startup, it is automatically processed, making the state of a freshly initialized cncjs-kt-ext instance be the same as if a probe was just completed.  This allows the (#autolevel_reapply) command to be issued immediately following a system reboot and still functions correctly.

Finally, probing can be done prior to loading any gcode. Additional optional parameters are added to the (#autolevel) command to explicitly set the width and height of the area to be probed, as well as bypass applying the probe data to any gcode.

All changes maintain backwards compatibility. For the average user not interested in using (PROBEOPEN), using this PR transparently saves and reloads probed data using the same processes and command structures as before.