### PR TITLE
Prevent `name` function from being copied into `options`

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ program.parse(process.argv)
 
 var options = {
   id: program.id,
-  name: program.name,
+  name: (typeof program.name == 'function') ? null : program.name,
   secret: program.secret,
   port: program.port,
   baudrate: program.baudrate,


### PR DESCRIPTION
Commander.js puts the [function `name()`](https://www.npmjs.com/package/commander#name) on the `program` object. That function is transferred over to the `options` object, so later on, setting a user in the configuration gets skipped. That results in a null name and user ID in the request.

The if statement below evaluates to false even when `name` is unset, because `options.name` exists as the function.

https://github.com/kreso-t/cncjs-kt-ext/blob/9e78be2c3989c4cf7b811f219940f6f49cfea0ab/index.js#L104