### PR TITLE
Accept commands from 'client' source

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Then, by using a macro you may send the following command:
 
 Without any options it will probe the area covered by the gcode every 10 mm, with travel height at 2 mm, and probing feedrate 50 mm/min.
     
-Please, note that this command will be ignored when put inside the gcode file or type it in the console, you must run it from a macro.
+Please, note that this command will be ignored when put inside the gcode file, you must run it from a macro.
 
 Once the probing is finished, the loaded gcode will be updated to reflect probed z levels and you may run the gcode.
 

--- a/index.js
+++ b/index.js
@@ -148,6 +148,8 @@ if (!options.id && !options.name) {
 const token = generateAccessToken({ id: options.id, name: options.name }, options.secret, options.accessTokenLifetime)
 const url = 'ws://' + options.socketAddress + ':' + options.socketPort + '?token=' + token
 
+const allowed_source = ['feeder', 'client']
+
 let socket = io.connect('ws://' + options.socketAddress + ':' + options.socketPort, {
   'query': 'token=' + token
 })
@@ -195,9 +197,9 @@ function callback(err, socket) {
 
   let autolevel = new Autolevel(socket, options)
   socket.on('serialport:write', function (data, context) {
-    if (data.indexOf('#autolevel_reapply') >= 0 && context && context.source === 'feeder') {
+    if (data.indexOf('#autolevel_reapply') >= 0 && context && allowed_source.indexOf(context.source) >= 0) {
       autolevel.reapply(data, context)
-    } else if (data.indexOf('#autolevel') >= 0 && context && context.source === 'feeder') {
+    } else if (data.indexOf('#autolevel') >= 0 && context && allowed_source.indexOf(context.source) >= 0) {
       autolevel.start(data, context)
     } else if (data.indexOf('PROBEOPEN') > 0) {
       console.log(`Probe file open command: ${data}`);


### PR DESCRIPTION
IMHO filtering the source of the command context confuses a lot of people because I would at first try to run this command from the console if the newly installed plugin even works correctly and only then I would create a macro for it (which is the only way to get this command accepted because macros are sent under different source then console).
I don't see a reason for this condition but there might be some, so please let me know if this change makes sense or not.